### PR TITLE
feat(ecdsa): ECDSAに対応させた

### DIFF
--- a/ecdsaJwk.go
+++ b/ecdsaJwk.go
@@ -1,0 +1,13 @@
+package public_key_handler
+
+type ECDSAJSONWebKey struct {
+	Kty string   `json:"kty"`
+	Crv string   `json:"crv"`
+	Kid string   `json:"kid"`
+	Use string   `json:"use"`
+	X   string   `json:"x"`
+	Y   string   `json:"y"`
+	X5c []string `json:"x5c"`
+}
+
+type ECDSAJWKs []ECDSAJSONWebKey

--- a/ecdsaPublicKey.go
+++ b/ecdsaPublicKey.go
@@ -1,0 +1,10 @@
+package public_key_handler
+
+import "crypto/ecdsa"
+
+type ECDSAPublicKey struct {
+	Id  string
+	Key ecdsa.PublicKey
+}
+
+type ECDSAPublicKeyMap map[string]ecdsa.PublicKey

--- a/handler.go
+++ b/handler.go
@@ -1,21 +1,32 @@
 package public_key_handler
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"math/big"
 	"net/http"
 )
 
-type PublicKeyHandler struct{
+type PublicKeyHandler struct {
 	httpClient *http.Client
 }
 
-type JWKResponse struct {
-	JWKs []JSONWebKey `json:"jwks"`
+type RSAJWKResponse struct {
+	JWKs []RSAJSONWebKey `json:"jwks"`
+}
+
+type ECDSAJWKResponse struct {
+	JWKs []ECDSAJSONWebKey `json:"jwks"`
+}
+
+func InvalidEllipticCurve(str string) error {
+	return errors.New("invalid elliptic curve: " + str)
 }
 
 func NewPublicKeyHandler() PublicKeyHandler {
@@ -24,23 +35,23 @@ func NewPublicKeyHandler() PublicKeyHandler {
 	}
 }
 
-func (handler PublicKeyHandler) GetPublicKeyMapFromJWKEndpoint(endpoint string) (RSAPublicKeyMap,error) {
-	response,err := handler.httpClient.Get(endpoint)
+func (handler PublicKeyHandler) GetRSAPublicKeyMapFromJWKEndpoint(endpoint string) (RSAPublicKeyMap, error) {
+	response, err := handler.httpClient.Get(endpoint)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
-	body,err := ioutil.ReadAll(response.Body)
+	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
-	var jwkResponse JWKResponse
-	if err := json.Unmarshal(body,&jwkResponse); err != nil {
-		return nil,err
+	var jwkResponse RSAJWKResponse
+	if err := json.Unmarshal(body, &jwkResponse); err != nil {
+		return nil, err
 	}
 	return handler.getRSAPublicKeyMapFromJWKs(jwkResponse.JWKs)
 }
 
-func (handler PublicKeyHandler) getRSAPublicKeyFromJWK(jwk JSONWebKey) (RSAPublicKey, error) {
+func (handler PublicKeyHandler) getRSAPublicKeyFromJWK(jwk RSAJSONWebKey) (RSAPublicKey, error) {
 	decodedN, err := base64.RawURLEncoding.DecodeString(jwk.N)
 	if err != nil {
 		return RSAPublicKey{}, err
@@ -62,7 +73,7 @@ func (handler PublicKeyHandler) getRSAPublicKeyFromJWK(jwk JSONWebKey) (RSAPubli
 	}, nil
 }
 
-func (handler PublicKeyHandler) getRSAPublicKeyMapFromJWKs(jwks JWKs) (RSAPublicKeyMap, error) {
+func (handler PublicKeyHandler) getRSAPublicKeyMapFromJWKs(jwks RSAJWKs) (RSAPublicKeyMap, error) {
 	keyMap := make(RSAPublicKeyMap)
 	for _, jwk := range jwks {
 		key, err := handler.getRSAPublicKeyFromJWK(jwk)
@@ -90,4 +101,65 @@ func decodeStringToUint64(str string) (uint64, error) {
 
 func decodeStringToBytes(str string) ([]byte, error) {
 	return base64.RawURLEncoding.DecodeString(str)
+}
+
+func (handler PublicKeyHandler) GetECDSAPublicKeyMapFromJWKEndpoint(endpoint string) (ECDSAPublicKeyMap, error) {
+	response, err := handler.httpClient.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var jwkResponse ECDSAJWKResponse
+	if err := json.Unmarshal(body, &jwkResponse); err != nil {
+		return nil, err
+	}
+	return handler.getECDSAPublicKeyMapFromJWKs(jwkResponse.JWKs)
+}
+
+func (handler PublicKeyHandler) getECDSAPublicKeyFromJWK(jwk ECDSAJSONWebKey) (ECDSAPublicKey, error) {
+	decodedX, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	if err != nil {
+		return ECDSAPublicKey{}, err
+	}
+	var keyX big.Int
+	keyX.SetBytes(decodedX)
+
+	decodedY, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	if err != nil {
+		return ECDSAPublicKey{}, err
+	}
+	var keyY big.Int
+	keyY.SetBytes(decodedY)
+
+	var curve elliptic.Curve
+	switch jwk.Crv {
+	case "P-256":
+		curve = elliptic.P256()
+	default:
+		return ECDSAPublicKey{}, InvalidEllipticCurve(jwk.Crv)
+	}
+
+	return ECDSAPublicKey{
+		Id: jwk.Kid,
+		Key: ecdsa.PublicKey{
+			Curve: curve,
+			X:     &keyX,
+			Y:     &keyY,
+		},
+	}, nil
+}
+
+func (handler PublicKeyHandler) getECDSAPublicKeyMapFromJWKs(jwks ECDSAJWKs) (ECDSAPublicKeyMap, error) {
+	keyMap := make(ECDSAPublicKeyMap)
+	for _, jwk := range jwks {
+		key, err := handler.getECDSAPublicKeyFromJWK(jwk)
+		if err != nil {
+			return nil, err
+		}
+		keyMap[key.Id] = key.Key
+	}
+	return keyMap, nil
 }

--- a/handler.go
+++ b/handler.go
@@ -136,8 +136,8 @@ func (handler PublicKeyHandler) getECDSAPublicKeyFromJWK(jwk ECDSAJSONWebKey) (E
 
 	var curve elliptic.Curve
 	switch jwk.Crv {
-	case "P-256":
-		curve = elliptic.P256()
+	case "P-384":
+		curve = elliptic.P384()
 	default:
 		return ECDSAPublicKey{}, InvalidEllipticCurve(jwk.Crv)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -41,7 +41,7 @@ func TestJWKHandler_getECDSAPublicKeyFromJWK(t *testing.T) {
 
 	jwk := ECDSAJSONWebKey{
 		Kty: "EC",
-		Crv: "P-256",
+		Crv: "P-384",
 		Kid: "tn1AViVj7vhk4TrdghT8Mw==",
 		X:   "sC1IpRQTKG3a_ULMXQZmP95vXUg3qWq1wUy_qIedfBU",
 		Y:   "74SsB5DCdaML6rt99v0DVPRIoGh0WR3G8mxYUr4uUtM",
@@ -52,7 +52,7 @@ func TestJWKHandler_getECDSAPublicKeyFromJWK(t *testing.T) {
 		t.Error(err)
 	}
 
-	wantCrv := "P-256"
+	wantCrv := "P-384"
 	if got := key.Key.Curve.Params().Name; got != wantCrv {
 		t.Errorf("want %v, got %v", wantCrv, got)
 	}
@@ -82,7 +82,7 @@ func TestJWKHandler_getECDSAPublicKeyMapFromJWKs(t *testing.T) {
 	jwks := ECDSAJWKs{
 		{
 			Kty: "EC",
-			Crv: "P-256",
+			Crv: "P-384",
 			Kid: "tn1AViVj7vhk4TrdghT8Mw==",
 			X:   "sC1IpRQTKG3a_ULMXQZmP95vXUg3qWq1wUy_qIedfBU",
 			Y:   "74SsB5DCdaML6rt99v0DVPRIoGh0WR3G8mxYUr4uUtM",

--- a/handler_test.go
+++ b/handler_test.go
@@ -35,3 +35,67 @@ func TestJWKHandler_decodeN(t *testing.T) {
 		t.Errorf("want %v, got %v", want, keyN)
 	}
 }
+
+func TestJWKHandler_getECDSAPublicKeyFromJWK(t *testing.T) {
+	handler := NewPublicKeyHandler()
+
+	jwk := ECDSAJSONWebKey{
+		Kty: "EC",
+		Crv: "P-256",
+		Kid: "tn1AViVj7vhk4TrdghT8Mw==",
+		X:   "sC1IpRQTKG3a_ULMXQZmP95vXUg3qWq1wUy_qIedfBU",
+		Y:   "74SsB5DCdaML6rt99v0DVPRIoGh0WR3G8mxYUr4uUtM",
+	}
+
+	key, err := handler.getECDSAPublicKeyFromJWK(jwk)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantCrv := "P-256"
+	if got := key.Key.Curve.Params().Name; got != wantCrv {
+		t.Errorf("want %v, got %v", wantCrv, got)
+	}
+
+	var wantX big.Int
+	wantX.SetString(
+		"79687070844812207596098443007393002297593322043514267675772315167913943071765",
+		0,
+	)
+	if got := key.Key.X; got.Cmp(&wantX) != 0 {
+		t.Errorf("want %v, got %v", wantX, got)
+	}
+
+	var wantY big.Int
+	wantY.SetString(
+		"108337181928287654206268663555247825023969395620689137485556592744914024813267",
+		0,
+	)
+	if got := key.Key.Y; got.Cmp(&wantY) != 0 {
+		t.Errorf("want %v, got %v", wantY, got)
+	}
+}
+
+func TestJWKHandler_getECDSAPublicKeyMapFromJWKs(t *testing.T) {
+	handler := NewPublicKeyHandler()
+
+	jwks := ECDSAJWKs{
+		{
+			Kty: "EC",
+			Crv: "P-256",
+			Kid: "tn1AViVj7vhk4TrdghT8Mw==",
+			X:   "sC1IpRQTKG3a_ULMXQZmP95vXUg3qWq1wUy_qIedfBU",
+			Y:   "74SsB5DCdaML6rt99v0DVPRIoGh0WR3G8mxYUr4uUtM",
+		},
+	}
+
+	keyMap, err := handler.getECDSAPublicKeyMapFromJWKs(jwks)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, ok := keyMap["tn1AViVj7vhk4TrdghT8Mw=="]
+	if !ok {
+		t.Error("key not found in got keyMap")
+	}
+}

--- a/rsaJwk.go
+++ b/rsaJwk.go
@@ -1,6 +1,6 @@
 package public_key_handler
 
-type JSONWebKey struct {
+type RSAJSONWebKey struct {
 	Kty string   `json:"kty"`
 	Kid string   `json:"kid"`
 	Use string   `json:"use"`
@@ -9,4 +9,4 @@ type JSONWebKey struct {
 	X5c []string `json:"x5c"`
 }
 
-type JWKs []JSONWebKey
+type RSAJWKs []RSAJSONWebKey


### PR DESCRIPTION
ECDSAに対応させました。

なお、既存のRSA系のものにすべてRSAというprefixをつけたことにともない、以下の破壊的変更が生じています。

BREAKING CHANGE:
rename GetPublicKeyMapFromJWKEndpoint >> GetRSAPublicKeyMapFromJWKEndpoint
rename JWKResponse >> RSAJWKResponse
rename JSONWebKey >> RSAJSONWebKey
rename JWKs >> RSAJWKs